### PR TITLE
Ohm model recipe

### DIFF
--- a/models/ohm.md
+++ b/models/ohm.md
@@ -1,7 +1,8 @@
 Ohm
 ------------
 
-[Ohm](http://ohm.keyvalue.org/) is an object hash-mapping library for the [Redis](http://redis.io/) database.
+[Ohm](http://ohm.keyvalue.org/) is an object hash-mapping library for 
+the [Redis](http://redis.io/) database.
 
 Require the Ohm gem in your app:
 


### PR DESCRIPTION
Description of how to include and use the Ohm object-hash-mapper gem for Redis.
