### PR TITLE
Remove preload_app config line from example unicorn config

### DIFF
--- a/deployment/nginx_proxied_to_unicorn.md
+++ b/deployment/nginx_proxied_to_unicorn.md
@@ -73,8 +73,6 @@ Once those are in place, we're ready to setup our `unicorn.rb` configuration.
     worker_processes 2
     working_directory @dir
 
-    preload_app true
-
     timeout 30
 
     # Specify path to socket unicorn listens to, 


### PR DESCRIPTION
Without a before_fork config block that disconnects the database connection,
this example code breaks when using ActiveRecord, Sequel, and possibly other
database libraries.  Many people copy this config without thinking about it
and report problems to unicorn or sequel due to this.

Further changes could be considered, such as only using multiple processes,
writing a pid file, and redirecting IO if you are daemonizing (check with
Unicorn::Configurator::RACKUP[:daemonize]).  Also, you are using a unix
socket in your configs, and providing a IP socket in your command line
example (-l 0.0.0.0:3001).  One or the other should probably be used
consistently, most likely dropping the -l option from the command line.
