### PR TITLE
Fixed link to models/mongo

### DIFF
--- a/databases/mongo.md
+++ b/databases/mongo.md
@@ -116,4 +116,4 @@ For more information on using the Ruby driver without an ORM take a look at [Mon
 
 [mongo]: http://www.mongodb.org/
 [rubydrivertutorial]: http://api.mongodb.org/ruby/current/file.TUTORIAL.html
-[mongo_models]: /p/models/mongo.md
+[mongo_models]: /p/models/mongo


### PR DESCRIPTION
Removed extension .md from Mongo Models URL. This URL http://recipes.sinatrarb.com/p/models/mongo.md currently issues a 500 error.
