### PR TITLE
databases/mongo: require json for .to_json

### DIFF
--- a/databases/mongo.md
+++ b/databases/mongo.md
@@ -18,6 +18,7 @@ to create a connection. You can do this in your _configure_ block:
     require 'rubygems'
     require 'sinatra'
     require 'mongo'
+    require 'json' # required for .to_json
   
     configure do
       conn = Mongo::Connection.new("localhost", 27017)


### PR DESCRIPTION
The examples in the next block use .to_json, and this needs a `require
'json'` on top.
