### PR TITLE
Change the RACK_ENV to 'test' in rspec's spec_helper.rb

### DIFF
--- a/testing/rspec.md
+++ b/testing/rspec.md
@@ -14,6 +14,8 @@ require 'rack/test'
 
 require File.expand_path '../../my-app.rb', __FILE__
 
+ENV['RACK_ENV'] = 'test'
+
 module RSpecMixin
   include Rack::Test::Methods
   def app() Sinatra::Application end


### PR DESCRIPTION
This extra setting is used by Sinatra's environment helpers.
Without it, Rspec will run your Sinatra application in development environment.
