### PR TITLE
Update MongoMapper require name.

### DIFF
--- a/models/mongo.md
+++ b/models/mongo.md
@@ -11,7 +11,7 @@ driver?](http://recipes.sinatrarb.com/p/databases/mongo?#article)
 ## MongoMapper
 
 ```ruby
-require 'mongomapper'
+require 'mongo_mapper'
 ```
 
 Create the Model class


### PR DESCRIPTION
The gem and require are both 'mongo_mapper' not 'mongomapper'.

Cheers!
