### PR TITLE
Update AssetPack recipe to use Foundation 5

### DIFF
--- a/asset_management/sinatra_assetpack.md
+++ b/asset_management/sinatra_assetpack.md
@@ -22,7 +22,6 @@ class App < Sinatra::Base
 end
 ```
 
-
 ## Generic Structure
 
 __Defaults__
@@ -169,9 +168,12 @@ gem install compass
 ```
 
 Install the `npm` modules of `bower` and `grunt-cli`. The instructions
-are provided [here](http://foundation.zurb.com/docs/sass.html). Then run
-`foundation new <project name>`. This will create a project with the
-following structure:
+are provided [here](http://foundation.zurb.com/docs/sass.html). Then
+run:
+
+    foundation new <project name>
+
+This will create a project with the following structure:
 
 ```
 bower_components/


### PR DESCRIPTION
This PR updates the `sinatra-assetpack` usage with Foundation 5 gem.
- In this text, there is a mini-introduction to the usage of  Foundation framework as well.
  Not a detailed one though.
- The reason for adding it in was that I couldn't find many texts online dealing with
  configuring Foundation with Sinatra.
