### PR TITLE
Stop by CTRL+C in "Embedding Sinatra within EventMachine" sample

### DIFF
--- a/embed/event-machine.md
+++ b/embed/event-machine.md
@@ -71,7 +71,8 @@ def run(opts)
       app:    dispatch,
       server: server,
       Host:   host,
-      Port:   port
+      Port:   port,
+      signals: false,
     })
   end
 end


### PR DESCRIPTION
The present sample does not stop when CTRL-C is pressed [*] because the signal
is processed by thin server. Set "signals" option to false to avoid this.

*: At least I've tested on Mac OS X (10.9.4) and Ubuntu (12.04).

I'm not sure whether you prefer to minimize the modification or to align indentation. I've choosed the former. If you think this pull request is acceptable but you prefer the latter, please tell me then I will to do so.

Thanks in advance.
