### PR TITLE
Updates I18n configuration instructions

### DIFF
--- a/development/i18n.md
+++ b/development/i18n.md
@@ -24,7 +24,7 @@ end
 ```
 
 **Note:** You may not wan't to override the I18n load path in case
-other gems have set it, (e.g. mongoid)
+other gems have set it, (e.g. mongoid). 
 If you don't wan't to override it, make sure you set it before you
 require your gems, or simply add your load path to the current one:
 


### PR DESCRIPTION
Updates instructions for setting or appending to the I18n.load_path
Overwriting I18n.load_path without precaution can cause unexpected errors.
