### PR TITLE
fix contributors avatars

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -250,7 +250,7 @@ html
               - @contributors.each do |contributor|
                 dt
                   a href="http://github.com/#{contributor["login"]}"
-                    img src="http://www.gravatar.com/avatar/#{contributor["gravatar_id"]}?s=50"
+                    img src="#{contributor["avatar_url"]}&s=50"
         #footer
           - if @readme
             hr
@@ -343,6 +343,8 @@ small
 
 #contributors dt
   display: inline-block
+  img
+    width: 50px
 
 #children
   ul li


### PR DESCRIPTION
Currently contributors section has broken avatars (https://yadi.sk/i/3KDIxW8vdSHqW).
I suggest to take them directly from Github instead of Gravatar. 
