### PR TITLE
Fix environment specification in RSpec recipe

### DIFF
--- a/testing/rspec.md
+++ b/testing/rspec.md
@@ -12,9 +12,9 @@ In your spec file or your spec helper, you can setup `Rack::Test` like this:
 require 'rack/test'
 require 'rspec'
 
-require File.expand_path '../../my-app.rb', __FILE__
-
 ENV['RACK_ENV'] = 'test'
+
+require File.expand_path '../../my-app.rb', __FILE__
 
 module RSpecMixin
   include Rack::Test::Methods


### PR DESCRIPTION
ENV['RACK_ENV'] must be set before the application is loaded - required for Sinatra configuration options for specific environments