### PR TITLE
Ignore vendor from sidebar

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -41,7 +41,7 @@ end
 Tilt.prefer Sinatra::Glorify::Template
 set :markdown, :layout_engine => :slim
 set :views, File.dirname(__FILE__)
-set :ignored_dirs, %w[tmp log config public bin activity]
+set :ignored_dirs, %w[tmp log config public bin activity vendor]
 
 before do
   @menu = Dir.glob("./*/").map do |file|


### PR DESCRIPTION
We have a link called [Vendor](http://recipes.sinatrarb.com/p/vendor?#article) in "Select a topic" and it doesn't work.

Check out [Japanese version](http://recipes.sinatrasapporo.org/) which already applies this commit.