### PR TITLE
Use request.params instead of params

### DIFF
--- a/databases/mongo.md
+++ b/databases/mongo.md
@@ -102,7 +102,7 @@ put '/update/:id/?' do
   content_type :json
   id = object_id(params[:id])
   settings.mongo_db.find(:_id => id).
-    find_one_and_update('$set' => params)
+    find_one_and_update('$set' => request.params)
   document_by_id(id)
 end
 


### PR DESCRIPTION
`find_one_and_update($set => params)` returns:

```ruby
{"_id"=>{"$oid"=>"5667a14856c02c0825000002"},
 "foo"=>"baz",
 "splat"=>[],
 "captures"=>["5667a14856c02c0825000002"],
 "id"=>"5667a14856c02c0825000002"}
```

Use `request.params` instead:

```ruby
{"_id"=>{"$oid"=>"5667a1fc56c02c0856000001"}, 
 "foo"=>"baz"}
```