### PR TITLE
Following this recipe, I had to add `zlib`

### DIFF
--- a/databases/postgresql-activerecord.md
+++ b/databases/postgresql-activerecord.md
@@ -71,6 +71,7 @@ end
 First, create a `Rakefile` or update your `Rakefile` to require `activerecord` and `activerecord/rake`
 
 ```
+require 'zlib'
 require 'sinatra/activerecord'
 require 'sinatra/activerecord/rake'
 require './app'


### PR DESCRIPTION
Otherwise I got this at `rake db:migrate`:

``` bash
NameError: uninitialized constant ActiveRecord::Migrator::Zlib
```

Not sure why though.
